### PR TITLE
Should prevent compile error

### DIFF
--- a/examples/face_landmark_detection_to_file.cpp
+++ b/examples/face_landmark_detection_to_file.cpp
@@ -45,7 +45,13 @@
 #include <dlib/image_io.h>
 #include <iostream>
 #include <dlib/opencv.h>
-#include <opencv2/highgui/highgui.hpp>
+
+#if CV_MAJOR_VERSION < 3
+#include <opencv2/highgui/highgui.hpp> // If you are using OpenCV 2
+#else
+#include <opencv2/imgproc.hpp> // If you are using OpenCV 3
+#endif
+
 #include "render_face.hpp" 
 
 using namespace dlib;


### PR DESCRIPTION
At least for me it worked. 
I installed opencv3 via 'brew' on Sierra and have no opencv 2.4 installed. I have not checked it for opencv 2.4.
Before Xcode 8 complained about "../dlib-master/examples/render_face.hpp:14:9: No member named 'polylines' in namespace 'cv'.